### PR TITLE
Researchsites: don't just check the repo status, actually pull it.

### DIFF
--- a/conf/post_deploy_actions.bash
+++ b/conf/post_deploy_actions.bash
@@ -44,6 +44,5 @@ if [ ! -d "$researchsites_dir" ]; then
     git clone --no-checkout ssh://git.mysociety.org/data/git/private/researchsites.git . && git checkout master
 else
     cd $researchsites_dir
-    git fetch origin
-    /data/mysociety/bin/git-safe-to-checkout . master
+    /data/mysociety/bin/git-safe-to-checkout . master && git pull
 fi


### PR DESCRIPTION
This adds the missing bit that will actually pull the [researchsites](https://github.com/mysociety/researchsites) repo on deploy, rather than just checking it's simply safe to do so :)