### PR TITLE
Bump Django to 3.2.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.13
+Django==3.2.14
 Markdown==2.6.8
 Pillow==9.0.1
 pyyaml==5.4


### PR DESCRIPTION
Bump Django due to security release.

See: https://www.djangoproject.com/weblog/2022/jul/04/security-releases/