### PR TITLE
Add open tracking view

### DIFF
--- a/repository/urls.py
+++ b/repository/urls.py
@@ -28,6 +28,7 @@ admin.autodiscover()
 
 urlpatterns = [
     url(r"^$", pageViews.HomeView.as_view(), name="home"),
+    url(r"^email/open/", views.tracking_open_view, name="open_view"),
     url(r"^admin/", admin.site.urls),
     url("^api/", include("repository.api_views")),
     url(r"^sitemap\.xml$", views.SitemapView.as_view(), name="sitemap"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ djangorestframework==3.13.1
 beautifulsoup4==4.11.1
 Whoosh==2.7.4
 django-haystack==3.2.1
+requests==2.31.0


### PR DESCRIPTION
This adds an experimental email open tracking view to the research website.

This returns a tracking pixel for an email, and logs the hit in google analytics.

The goal of this is to be able to have an aggregate open view for email campaigns, while not using the default mailchimp which tracks individuals. 

In principle this could be moved to another url/project - nothing is stored locally. 

The format below should add an image for a campaign:

https://research.mysociety.org/email/open/?campaign=demo